### PR TITLE
Fix container health check and Docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - TZ=${TZ:-UTC}
       - DEBUG=${DEBUG:-false}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:52638/health"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:52638/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This PR fixes the container health check and Docker configuration:

- Move health check endpoint before middleware to avoid 404 errors
- Simplify health check response
- Update Docker health check command to use wget
- Fix data directory permissions

Changes:
- Move `/health` endpoint before middleware setup
- Add proper JSON response with status, version, and commit info
- Update Docker health check to use `wget -qO-`
- Fix data directory permissions

To test the changes:
```bash
# Clean up existing containers and volumes
docker-compose down -v

# Start the application
docker-compose up -d

# Check container health
docker ps

# Test health check endpoint
curl http://localhost:52638/health
```

The container should now be marked as healthy, and the health check endpoint should return:
```json
{
  "status": "ok",
  "version": "dev",
  "commit": "unknown"
}
```