### PR TITLE
Update Go version and fix health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 
@@ -52,7 +52,7 @@ ENV TZ=UTC \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT}/health || exit 1
+    CMD wget -qO- http://localhost:${PORT}/health || exit 1
 
 # Run the application
 CMD ["./unifi-dns-manager", "-port", "52638", "-data-dir", "/app/data"]


### PR DESCRIPTION
This PR updates Go version and fixes the health check:

- Update to Go 1.22
- Use http.NewServeMux for better route handling
- Fix health check endpoint
- Update Docker health check command

Changes:
- Update to latest Go version (1.22)
- Use http.NewServeMux for proper route handling
- Move health check endpoint before middleware
- Update Docker health check command

To test the changes:
```bash
# Clean up existing containers and volumes
docker-compose down -v

# Start the application
docker-compose up -d

# Check container health
docker ps

# Test health check endpoint
curl http://localhost:52638/health
```

The container should now be marked as healthy, and the health check endpoint should return:
```json
{
  "status": "ok",
  "version": "dev",
  "commit": "unknown"
}
```